### PR TITLE
added missing tag to fix the cleanup docs

### DIFF
--- a/AMSV3Tutorials/AnalyzeVideos/Program.cs
+++ b/AMSV3Tutorials/AnalyzeVideos/Program.cs
@@ -463,6 +463,7 @@ namespace AnalyzeVideos
 
             client.ContentKeyPolicies.Delete(resourceGroupName, accountName, contentKeyPolicyName);
         }
+        // </CleanUp>
 
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
The AzureDocs sample [here](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/media-services/latest/analyze-videos-tutorial-with-api.md) references this code sample, however, due to the missing closing tag on the CleanUp sample, the [sample does not show up](https://docs.microsoft.com/en-us/azure/media-services/latest/analyze-videos-tutorial-with-api#clean-up-resource-in-your-media-services-account)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->